### PR TITLE
Add platform-agnostic demo setup for SQL Server integration

### DIFF
--- a/sqlserver/Makefile
+++ b/sqlserver/Makefile
@@ -1,0 +1,24 @@
+.PHONY: all up build run logs down clean
+
+# Start only the MSSQL service
+up:
+	docker compose up -d
+
+# Build the Python load generator Docker image
+build:
+	docker build -t loadgen-py ./load-generator
+
+# Run the load generator container and connect it to the MSSQL container network
+run:
+	docker run --network=mssql-load-generator_mssql-network --rm loadgen-py
+
+# Show live container logs
+logs:
+	docker compose logs -f
+
+# Stop and remove containers + volumes
+down:
+	docker compose down -v 
+
+# Clean all and rerun the whole process
+all: up build run

--- a/sqlserver/README.md
+++ b/sqlserver/README.md
@@ -1,0 +1,23 @@
+# MSSQL Load Generator
+
+This project sets up a SQL Server using Docker and generates database load using a Python script packaged in a Docker container.
+
+---
+
+## 📦 Requirements
+
+- Docker & Docker Compose
+- GNU Make (for running commands easily)
+- (Optional) Python 3.8+ and ODBC driver if you want to run the script outside Docker
+
+---
+
+## 🚀 Project Setup
+
+### ✅ Clone the project
+
+```bash
+git clone https://github.com/middleware-labs/integration-demo-projects.git
+cd sqlserver
+make all  # 🚀 This starts MSSQL, builds the load generator, and inserts sample data
+```

--- a/sqlserver/docker-compose.yml
+++ b/sqlserver/docker-compose.yml
@@ -1,0 +1,27 @@
+name: mssql-load-generator
+version: '3.1'
+services:
+  mssql:
+    container_name: mssql-db
+    hostname: mssql-db-host
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "Admin@123"
+      MSSQL_PID: 'Developer'
+      MSSQL_AGENT_ENABLED: "true"
+      MSSQL_TCP_PORT: 1433
+      MSSQL_ENABLE_HADR: "1"
+    ports:
+      - "1433:1433"
+    volumes:
+      - mssql_data:/var/opt/mssql
+    networks:
+      - mssql-network
+
+networks:
+  mssql-network:
+
+volumes:
+  mssql_data:
+    driver: local

--- a/sqlserver/load-generator/Dockerfile
+++ b/sqlserver/load-generator/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.10-slim
+
+# Install dependencies for pyodbc + MSSQL ODBC driver
+RUN apt-get update && \
+    apt-get install -y gcc g++ gnupg curl unixodbc-dev libgssapi-krb5-2 && \
+    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+    curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+    apt-get update && ACCEPT_EULA=Y apt-get install -y msodbcsql17 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create app directory
+WORKDIR /app
+
+# Copy files
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py .
+
+# Run the script
+CMD ["python", "main.py"]

--- a/sqlserver/load-generator/main.py
+++ b/sqlserver/load-generator/main.py
@@ -1,0 +1,50 @@
+import pyodbc
+import time
+from faker import Faker
+
+SERVER = 'mssql-db-host'
+DATABASE = 'master'
+USERNAME = 'sa'
+PASSWORD = 'Admin@123'
+DRIVER = 'ODBC Driver 17 for SQL Server'
+
+CONN_STR = f'DRIVER={{{DRIVER}}};SERVER={SERVER};DATABASE={DATABASE};UID={USERNAME};PWD={PASSWORD}'
+
+MAX_RETRIES = 10
+
+# Retry logic to wait for SQL Server to be ready
+for attempt in range(MAX_RETRIES):
+    try:
+        conn = pyodbc.connect(CONN_STR, timeout=5)
+        print("✅ Connected to SQL Server")
+        break
+    except pyodbc.Error as e:
+        print(f"⏳ Waiting for SQL Server... (attempt {attempt + 1}/{MAX_RETRIES})")
+        time.sleep(5)
+else:
+    print("❌ Could not connect to SQL Server after retries")
+    raise SystemExit(1)
+
+cursor = conn.cursor()
+
+# Create table and insert fake data
+cursor.execute('''
+    IF NOT EXISTS (
+        SELECT * FROM sysobjects WHERE name='users' and xtype='U'
+    )
+    CREATE TABLE users (
+        id INT IDENTITY(1,1) PRIMARY KEY,
+        name NVARCHAR(100),
+        email NVARCHAR(100),
+        address NVARCHAR(255)
+    )
+''')
+conn.commit()
+
+fake = Faker()
+for _ in range(10):
+    cursor.execute("INSERT INTO users (name, email, address) VALUES (?, ?, ?)",
+                   fake.name(), fake.email(), fake.address())
+conn.commit()
+conn.close()
+print("✅ Inserted fake users successfully.")

--- a/sqlserver/load-generator/requirements.txt
+++ b/sqlserver/load-generator/requirements.txt
@@ -1,0 +1,2 @@
+pyodbc
+faker

--- a/sqlserver/load-generator/run.sh
+++ b/sqlserver/load-generator/run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+echo "📦 Starting MSSQL container..."
+docker-compose up -d
+
+echo "⏳ Waiting for MSSQL to initialize (10s)..."
+sleep 10
+
+echo "🐍 Building Python load generator image..."
+docker build -t loadgen-py ./load-generator
+
+echo "🚀 Running the load generator container..."
+docker run --network=mssql-load-generator_mssql-network --rm loadgen-py


### PR DESCRIPTION
### Description:

- This PR adds a fully self-contained demo environment for SQL Server integration using Docker and a custom Python-based load generator.
- It is designed to help simulate real SQL workloads and can be used for local testing or integration validation. The setup is simple, reproducible, and runs with a single make all command.

### 📁 What's Included:

- `docker-compose.yml` to spin up a SQL Server instance.
- `load-generator`/ directory with a Python script to simulate query load.
- `Makefile` to simplify common tasks like building, running, and cleaning the setup.
- `README.md` with clear instructions.

### 🚀 Project Setup:

- git clone https://github.com/middleware-labs/integration-demo-projects.git
- cd sqlserver
- make all  # 🚀 This starts MSSQL, builds the load generator, and inserts sample data

### 📌 What `make all` Does:

- `up` – Starts the SQL Server container via Docker Compose.
- `build` – Builds the Python-based load generator Docker image.
- `run` – Runs the load generator and connects it to the same Docker network as SQL Server to simulate real query load.
- `logs` – Lets you follow container logs (optional).
- `down` – Stops and removes containers and volumes.
